### PR TITLE
Combine login and chat into a single authenticated app

### DIFF
--- a/UI/streamlit_chat/login.py
+++ b/UI/streamlit_chat/login.py
@@ -1,49 +1,7 @@
+"""Deprecated entry point kept for backward compatibility."""
 import streamlit as st
-import json
-from streamlit_js_eval import streamlit_js_eval
 
-FASTAPI_BASE = "http://127.0.0.1:8000"  # adjust if you used another host/port
+from app import main
 
-st.set_page_config(page_title="Hello World", page_icon="👋", layout="centered")
-
-st.title("Hello World (FastAPI-authenticated)")
-
-# Ask the BROWSER to fetch /me so cookies are sent automatically
-js = f"""
-(async () => {{
-  try {{
-    const res = await fetch("{FASTAPI_BASE}/me", {{
-      method: "GET",
-      credentials: "include"  // send cookies
-    }});
-    const data = await res.json();
-    return JSON.stringify(data);
-  }} catch (e) {{
-    return JSON.stringify({{ error: String(e) }});
-  }}
-}})()
-"""
-
-result = streamlit_js_eval(js_expressions=js, key="auth-check")
-
-if result is None:
-    st.info("Checking login status…")
-    st.stop()
-
-try:
-    payload = json.loads(result)
-except Exception:
-    payload = {"error": "Invalid JSON from /me"}
-
-# Show UI based on FastAPI's answer
-if payload.get("error"):
-    st.error(f"Auth check failed: {payload['error']}")
-elif payload.get("authenticated"):
-    user = payload.get("user", {})
-    name = user.get("name") or user.get("email") or "user"
-    st.success(f"Welcome, {name}! 🎉")
-    st.write("This is your protected Hello World page.")
-    st.link_button("Log out", f"{FASTAPI_BASE}/logout", type="secondary")
-else:
-    st.warning("You are not logged in.")
-    st.link_button("Continue with Google", f"{FASTAPI_BASE}/login", type="primary")
+st.warning("The login flow has moved into app.py. Redirecting you there…")
+main()


### PR DESCRIPTION
## Summary
- merge the login flow into the primary Streamlit chat application
- require successful authentication before displaying the chat interface and expose login/logout controls in the top-right corner
- keep login.py as a compatibility wrapper that delegates to the new combined app

## Testing
- not run (Streamlit UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e1b602f5188325b1abfe6ae37dd751